### PR TITLE
base: Bluetooth: add "Accept all files" option for incoming files [2/3]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -4095,15 +4095,22 @@ public final class Settings {
          * @hide
          */
          public static final String TOAST_ICON = "toast_icon";
- 
+
        /**
         * Whether to show the battery info on the lockscreen while charging
         * @hide
         */
          public static final String LOCKSCREEN_BATTERY_INFO = "lockscreen_battery_info";
- 
-       /** 
+
+        /**
 	 * Settings to backup. This is here so that it's in the same place as the settings
+         * If all file types can be accepted over Bluetooth OBEX.
+         * @hide
+         */
+          public static final String BLUETOOTH_ACCEPT_ALL_FILES = "bluetooth_accept_all_files";
+
+        /**
+         * Settings to backup. This is here so that it's in the same place as the settings
          * keys and easy to update.
          *
          * NOTE: Settings are backed up and restored in the order they appear


### PR DESCRIPTION
 * Renamed some variable.
 * Re-organized the comment.
 * Reworded the commit message.

  This patch will make OBEX server respect the "accept all files"
  setting. If enabled, it will skip checking MIME type of incoming file,
  so the file types not present in whitelist can be accepted.
  Blacklist will be ignored as well. (There's nothing in blacklist in fact)
  If it's disabled, the check will be performed as usual.

Change-Id: I3904a25914d16d040126de43f5e6ed51993494c4

Signed-off-by: Sathish2026 <txt2sathish@gmail.com>