### PR TITLE
Roundcorners:nuke gap between content and corners

### DIFF
--- a/packages/SystemUI/res/values-sw372dp/dimens.xml
+++ b/packages/SystemUI/res/values-sw372dp/dimens.xml
@@ -16,6 +16,6 @@
 */
 -->
 <resources>
-    <dimen name="nav_content_padding">8dp</dimen>
-    <dimen name="rounded_corner_content_padding">8dp</dimen>
+    <dimen name="nav_content_padding">0dp</dimen>
+    <dimen name="rounded_corner_content_padding">0dp</dimen>
 </resources>


### PR DESCRIPTION
This commit removes the gap between the content and corners of statusbar